### PR TITLE
Replace URL with new filter URL

### DIFF
--- a/Resources/Public/JavaScript/search_controller.js
+++ b/Resources/Public/JavaScript/search_controller.js
@@ -27,6 +27,7 @@ function SearchController() {
                 _this.scrollToTopOfElement(solrParent, 50);
                 jQuery("body").trigger("tx_solr_updated");
                 loader.fadeOut().remove();
+                history.replaceState({}, null, uri.removeQuery("type").href());
             }
         );
         return false;


### PR DESCRIPTION
If a user clicks on a search result the appropriate page/content is loaded. When going back (browser back) the search page is loaded, but without the chosen filter options. By replacing the current browser URL after the AJAX call is returned, is is possible to go back to the search page with the chosen filter options already set.

# What this pr does

It replaces the current browsers URL with the filter URL, in order to come back to the search page with the already chosen options set.

# How to test

- Have a search result page with facet options
- Use the static solr typoscript template for ajaxify search results
- Choose a filter option
- See the current URL be replaced with the filter option URL
